### PR TITLE
warn about bundler < 1.6.5

### DIFF
--- a/app/views/system_devices/create.html.erb
+++ b/app/views/system_devices/create.html.erb
@@ -1,7 +1,7 @@
 <div class="jumbotron bundler-instructions">
   <h1>Almost done!</h1>
   <p>
-    You need to configure bundler (>= 1.6.0) to use these new credentials to access this gem server.
+    You need to configure bundler (>= 1.6.5) to use these new credentials to access this gem server.
     These settings are stored in ~/.bundler/config. You can add the credentials to by running the command below.
     <strong>We are never going to show this secret key to you again.</strong>
   </p>


### PR DESCRIPTION
https://github.com/bundler/bundler/issues/3045 causes credentials to appear in lock file.

@zendesk/octo @osheroff 
