### PR TITLE
Avoid "Undefined method dependencies for nil::Class"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   include Auth
   protect_from_forgery with: :exception
-  force_ssl unless Rails.env.test?
+  force_ssl if Rails.env.production?
 end

--- a/config/initializers/geminabox.rb
+++ b/config/initializers/geminabox.rb
@@ -5,7 +5,7 @@ Geminabox.views = Rails.root + 'app/views/gems'
 # Geminabox.rubygems_proxy = true
 
 ssl_and_auth = -> {
-  if !request.ssl? && !Rails.env.test?
+  if !request.ssl? && Rails.env.production?
     redirect url.sub('http://', 'https://')
   end
 

--- a/lib/helpers/geminabox.rb
+++ b/lib/helpers/geminabox.rb
@@ -59,7 +59,10 @@ module Helpers::Geminabox
       next if version.name == name
 
       latest_spec = spec_for(name, versions.newest.number)
+      next unless latest_spec
+
       dependencies = latest_spec.dependencies
+      next unless dependencies
 
       dependent = dependencies.detect do |d|
         d.name == version.name && d.requirement.satisfied_by?(version.number)


### PR DESCRIPTION
Hi!, 
I'm getting a 500 when I can't get the dependencies from the current gem:

```
# lib/helpers/geminabox.rb:61
latest_spec = spec_for(name, versions.newest.number)
dependencies = latest_spec.dependencies
```

- Related: https://github.com/geminabox/geminabox/blob/46c5a1df162c58dd1317275c6cfb8e6da6c7747e/lib/geminabox/server.rb#L271

I wonder if I can't just skip that specific gem and continue without breaking the whole page (?)
**Plus:** I think it would be easy if test/dev envs does not enforce SSL by default. 