### PR TITLE
Allow token based gem fetching

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,0 +1,12 @@
+class TokensController < ApplicationController
+  skip_before_filter :authenticate!, :verify_authenticity_token
+
+  def show
+    device = authenticate_with_http_basic{|identifier,password|
+      Device.find_by_identifier(identifier).try(:authenticate, password)
+    }
+
+    render text: device.generate_token
+  end
+end
+

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -8,6 +8,33 @@ class Device < ActiveRecord::Base
   before_validation :generate_identifier, :on => :create
   before_validation :generate_password, :on => :create
 
+  def generate_token
+    data = JSON.dump(id: id, time: Time.now.to_i)
+
+    cipher = OpenSSL::Cipher::AES.new(256, :CBC)
+    cipher.encrypt
+    cipher.key = Rails.application.config.device_cipher_key
+    iv = cipher.random_iv
+
+    encrypted = cipher.update(data) + cipher.final
+    CGI.escape(Base64.encode64(iv)) + ":" + CGI.escape(Base64.encode64(encrypted))
+  end
+
+  def self.find_by_token(iv, encrypted)
+    decipher = OpenSSL::Cipher::AES.new(256, :CBC)
+    decipher.decrypt
+    decipher.key = Rails.application.config.device_cipher_key
+    decipher.iv = iv
+
+    plain = decipher.update(encrypted) + decipher.final
+    hash = JSON.parse(plain)
+    if Time.at(hash['time']) > Rails.application.config.token_expiration.ago
+      find(hash['id'])
+    else
+      false
+    end
+  end
+
   def used!
     update_attribute(:used_at, Time.now)
   end

--- a/config/initializers/device_crypto.rb
+++ b/config/initializers/device_crypto.rb
@@ -1,0 +1,4 @@
+cipher = OpenSSL::Cipher::AES.new(256, :CBC)
+cipher.encrypt
+Rails.application.config.device_cipher_key = cipher.random_key
+Rails.application.config.token_expiration = 20.minutes

--- a/config/initializers/geminabox.rb
+++ b/config/initializers/geminabox.rb
@@ -18,6 +18,10 @@ ssl_and_auth = -> {
     if auth.provided? && auth.basic? && auth.credentials
       identifier, password = auth.credentials
       device = Device.find_by_identifier(identifier).try(:authenticate, password)
+      unless device
+        decode = Proc.new{ |string| Base64.decode64(CGI.unescape(string)) }
+        device = Device.find_by_token(decode[identifier], decode[password])
+      end
     end
 
     if device.try(:user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy'
   get '/auth/:provider/callback', to: 'sessions#create'
   post '/auth/:provider/callback', to: 'sessions#create'
+  get '/tokens', to: "tokens#show"
 
   mount Geminabox::Server, :at => '/gems', :as => 'geminabox'
 end


### PR DESCRIPTION
By creating an encrypted and expiring message we can allow for sharing the
message over insecure transports IE. Docker images.

The idea is that the user will first request a "token" which is an encrypted
message containing the device id and a timestamp when the token was generated.
This token is unreadable to anyone but the instance that generated the token. (This will be a problem if we're running more than one unicorn).

The user may then substitute regular credentials with the generated token for
use with Bundler to fetch gems from the gemserver.

/cc @jonmoter @grosser who else?