### PR TITLE
only load the last 20 versions for a gem

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,0 +1,37 @@
+class VersionsController < ApplicationController
+  include Helpers::Geminabox
+
+  helper_method :link_to_gem, :reverse_dependencies, :load_gems
+
+  def show
+    # Taken from https://github.com/geminabox/geminabox/blob/0.12.4/lib/geminabox/server.rb#L108-L109
+    gems = Hash[server_instance.send(:load_gems).by_name]
+    @gem = gems[params['gemname']]
+    @version = @gem && @gem.find { |g| g.number = params['version'] }
+
+    unless @version
+      render nothing: true, status: :not_found
+      return
+    end
+
+    @spec = server_instance.send(:spec_for, @version.name, @version.number)
+  end
+
+  private
+
+  # Allows us to use the instance methods defined in Geminabox::Server.
+  #
+  # We use .new! as defined by Sinatra so we get a class instance and not a
+  # Sinatra::Wrapper instance.
+  def self.server_instance
+
+  end
+
+  def server_instance
+    @server_instance ||= Geminabox::Server.new!
+  end
+
+  def load_gems
+    server_instance.send(:load_gems)
+  end
+end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,16 +1,14 @@
 class VersionsController < ApplicationController
-  include Helpers::Geminabox
-
-  helper_method :link_to_gem, :reverse_dependencies, :load_gems
+  helper Helpers::Geminabox
+  helper_method :load_gems
 
   def show
-    # Taken from https://github.com/geminabox/geminabox/blob/0.12.4/lib/geminabox/server.rb#L108-L109
-    gems = Hash[server_instance.send(:load_gems).by_name]
-    @gem = gems[params['gemname']]
-    @version = @gem && @gem.find { |g| g.number = params['version'] }
+    @version = server_instance.find_gem_by_name(params['gemname']).detect do |v|
+      v.number.to_s == params['version']
+    end
 
     unless @version
-      render nothing: true, status: :not_found
+      head :not_found
       return
     end
 
@@ -23,10 +21,6 @@ class VersionsController < ApplicationController
   #
   # We use .new! as defined by Sinatra so we get a class instance and not a
   # Sinatra::Wrapper instance.
-  def self.server_instance
-
-  end
-
   def server_instance
     @server_instance ||= Geminabox::Server.new!
   end

--- a/app/views/gems/_version_details.erb
+++ b/app/views/gems/_version_details.erb
@@ -1,0 +1,24 @@
+<div class="row">
+  <div class="col-md-4">
+    <h4>Runtime Dependencies</h4>
+    <ul class="list-unstyled">
+      <%= partial_collection(:gem_dependency, spec.runtime_dependencies) %>
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h4>Development Dependencies</h4>
+    <ul class="list-unstyled">
+      <%= partial_collection(:gem_dependency, spec.development_dependencies) %>
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h4>Dependents</h4>
+    <ul class="list-unstyled">
+      <%= partial_collection(:gem_dependency, reverse_dependencies(version)) %>
+    </ul>
+  </div>
+</div>
+
+<a href="<%= url("/gems/#{version.gemfile_name}.gem") %>" class="btn btn-danger" data-confirm="Really?" data-method="delete">
+  Delete
+</a>

--- a/app/views/gems/_version_details.erb
+++ b/app/views/gems/_version_details.erb
@@ -19,6 +19,4 @@
   </div>
 </div>
 
-<a href="<%= url("/gems/#{version.gemfile_name}.gem") %>" class="btn btn-danger" data-confirm="Really?" data-method="delete">
-  Delete
-</a>
+<%= link_to 'Delete', "#{geminabox_path}/gems/#{version.gemfile_name}.gem", class: 'btn btn-danger', data: {confirm: 'Really?'}, method: :delete %>

--- a/app/views/gems/gem.erb
+++ b/app/views/gems/gem.erb
@@ -1,5 +1,9 @@
+<% VERSION_LIMIT = 3 %>
 <% @gem.by_name do |name, versions| %>
   <% latest_spec = spec_for(name, versions.newest.number) %>
+  <% ordered_versions_array = versions.to_a.reverse %>
+  <% recent_versions = ordered_versions_array.first(VERSION_LIMIT) %>
+  <% old_versions = Array(ordered_versions_array[VERSION_LIMIT..-1]) %>
   <div class="page-header">
     <h1>
       <%= name %>
@@ -10,7 +14,7 @@
   </div>
 
   <div class="panel-group" id="versions">
-    <% versions.last(20).reverse_each do |version| %>
+    <% recent_versions.each do |version| %>
       <% spec = spec_for(version.name, version.number) %>
       <% number_class = version.number.to_s.tr('.', '_') %>
 
@@ -30,31 +34,20 @@
 
         <div id="version-<%= number_class %>" class="panel-collapse collapse <%= version == versions.newest ? 'in' : '' %>">
           <div class="panel-body">
-            <div class="row">
-              <div class="col-md-4">
-                <h4>Runtime Dependencies</h4>
-                <ul class="list-unstyled">
-                  <%= partial_collection(:gem_dependency, spec.runtime_dependencies) %>
-                </ul>
-              </div>
-              <div class="col-md-4">
-                <h4>Development Dependencies</h4>
-                <ul class="list-unstyled">
-                  <%= partial_collection(:gem_dependency, spec.development_dependencies) %>
-                </ul>
-              </div>
-              <div class="col-md-4">
-                <h4>Dependents</h4>
-                <ul class="list-unstyled">
-                  <%= partial_collection(:gem_dependency, reverse_dependencies(version)) %>
-                </ul>
-              </div>
-            </div>
-
-            <a href="<%= url("/gems/#{version.gemfile_name}.gem") %>" class="btn btn-danger" data-confirm="Really?" data-method="delete">
-              Delete
-            </a>
+            <%= erb :_version_details, {}, spec: spec, version: version %>
           </div>
+        </div>
+      </div>
+    <% end %>
+    <% old_versions.each do |version| %>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <a href="<%= gem_version_path(gemname: name, version: version.number) %>">
+            <h4 class="panel-title">
+              <strong><%= version.name %></strong>
+              <%= version.number %>
+            </h4>
+          </a>
         </div>
       </div>
     <% end %>

--- a/app/views/gems/gem.erb
+++ b/app/views/gems/gem.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class="panel-group" id="versions">
-    <% versions.reverse_each do |version| %>
+    <% versions.last(20).reverse_each do |version| %>
       <% spec = spec_for(version.name, version.number) %>
       <% number_class = version.number.to_s.tr('.', '_') %>
 

--- a/app/views/gems/gem.erb
+++ b/app/views/gems/gem.erb
@@ -1,9 +1,7 @@
-<% VERSION_LIMIT = 3 %>
 <% @gem.by_name do |name, versions| %>
   <% latest_spec = spec_for(name, versions.newest.number) %>
-  <% ordered_versions_array = versions.to_a.reverse %>
-  <% recent_versions = ordered_versions_array.first(VERSION_LIMIT) %>
-  <% old_versions = Array(ordered_versions_array[VERSION_LIMIT..-1]) %>
+  <% versions_array = versions.to_a.reverse %>
+  <% recent_versions = versions_array.slice!(0, RECENT_GEM_VERSIONS_TO_SHOW) %>
   <div class="page-header">
     <h1>
       <%= name %>
@@ -31,7 +29,6 @@
             </a>
           </h4>
         </div>
-
         <div id="version-<%= number_class %>" class="panel-collapse collapse <%= version == versions.newest ? 'in' : '' %>">
           <div class="panel-body">
             <%= erb :_version_details, {}, spec: spec, version: version %>
@@ -39,7 +36,8 @@
         </div>
       </div>
     <% end %>
-    <% old_versions.each do |version| %>
+
+    <% versions_array.each do |version| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <a href="<%= gem_version_path(gemname: name, version: version.number) %>">

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -5,34 +5,11 @@
     <span class="label label-primary pull-right"><%= @version.number %></span>
   </h1>
   <p class="lead"><%= @spec.description %></p>
+  <p>
+    <% if uploader = Uploader.find_by(gem_name: @spec.name, gem_version: @spec.version.to_s) %>
+      Uploaded by <%= uploader.user.try(:email) %> at <%= uploader.created_at.to_s(:db) %> UTC
+    <% end %>
+  </p>
 </div>
-<div class="row">
-  <div class="col-md-4">
-    <h4>Runtime Dependencies</h4>
-    <ul class="list-unstyled">
-      <% @spec.runtime_dependencies.each do |d| %>
-        <%= link_to_gem(d.name) %> <%= d.requirement %>
-        <br>
-      <% end %>
-    </ul>
-  </div>
-  <div class="col-md-4">
-    <h4>Development Dependencies</h4>
-    <ul class="list-unstyled">
-      <% @spec.development_dependencies.each do |d| %>
-        <%= link_to_gem(d.name) %> <%= d.requirement %>
-        <br>
-      <% end %>
-    </ul>
-  </div>
-  <div class="col-md-4">
-    <h4>Dependents</h4>
-    <ul class="list-unstyled">
-      <% reverse_dependencies(@version).each do |d| %>
-        <%= link_to_gem(d.name) %> <%= d.requirement %>
-        <br>
-      <% end %>
-    </ul>
-  </div>
-</div>
-<%= link_to 'Delete', "/gems/#{@version.gemfile_name}.gem", class: 'btn btn-danger', data: {confirm: 'Really?'}, method: :delete %>
+
+<%= render 'gems/version_details', version: @version, spec: @spec %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -1,0 +1,38 @@
+<div class="page-header">
+  <h1>
+    <%= @version.name %>
+    <small><%= @spec.summary %></small>
+    <span class="label label-primary pull-right"><%= @version.number %></span>
+  </h1>
+  <p class="lead"><%= @spec.description %></p>
+</div>
+<div class="row">
+  <div class="col-md-4">
+    <h4>Runtime Dependencies</h4>
+    <ul class="list-unstyled">
+      <% @spec.runtime_dependencies.each do |d| %>
+        <%= link_to_gem(d.name) %> <%= d.requirement %>
+        <br>
+      <% end %>
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h4>Development Dependencies</h4>
+    <ul class="list-unstyled">
+      <% @spec.development_dependencies.each do |d| %>
+        <%= link_to_gem(d.name) %> <%= d.requirement %>
+        <br>
+      <% end %>
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h4>Dependents</h4>
+    <ul class="list-unstyled">
+      <% reverse_dependencies(@version).each do |d| %>
+        <%= link_to_gem(d.name) %> <%= d.requirement %>
+        <br>
+      <% end %>
+    </ul>
+  </div>
+</div>
+<%= link_to 'Delete', "/gems/#{@version.gemfile_name}.gem", class: 'btn btn-danger', data: {confirm: 'Really?'}, method: :delete %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
+RECENT_GEM_VERSIONS_TO_SHOW = 20
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,19 +1,25 @@
 Rails.application.routes.draw do
-  resources :users, :only => [:index, :destroy] do
+  root 'home#show'
+
+  resources :users, only: [:index, :destroy] do
     member do
       patch :make_admin
       patch :make_non_admin
     end
   end
-  resources :devices, :only => [:index, :new, :create, :destroy]
-  resources :system_devices, :only => [:index, :new, :create, :destroy]
 
-  root 'home#show'
+  resources :devices, only: [:index, :new, :create, :destroy]
+  resources :system_devices, only: [:index, :new, :create, :destroy]
+
   get '/server_status', to: 'status#status'
-  get '/login', to: 'sessions#new'
+
+  get '/login',  to: 'sessions#new'
   get '/logout', to: 'sessions#destroy'
-  get '/auth/:provider/callback', to: 'sessions#create'
+
+  get  '/auth/:provider/callback', to: 'sessions#create'
   post '/auth/:provider/callback', to: 'sessions#create'
 
-  mount Geminabox::Server, :at => '/gems', :as => 'geminabox'
+  get '/gems/:gemname/versions/:version', to: 'versions#show', as: :gem_version, version: /.*/
+
+  mount Geminabox::Server, at: '/gems', as: 'geminabox'
 end

--- a/lib/helpers/geminabox.rb
+++ b/lib/helpers/geminabox.rb
@@ -29,8 +29,14 @@ module Helpers::Geminabox
 
   def partial_collection(template, collection)
     collection.map do |object|
-      erb("_#{template}".to_sym, :layout => false, :locals => { template => object })
-    end.join
+      # both rails and sinatra are using this helper, so we need to check how to
+      # evaluate the template
+      if respond_to? :erb
+        erb :"_#{template}", layout: false, locals: { template => object }
+      else
+        render "gems/#{template}", template => object
+      end
+    end.join.html_safe
   end
 
   def find_gem_by_name(name)


### PR DESCRIPTION
The show page for a gem is pretty expensive. It has to unzip+unmarshal the gemspec file for every version of the gem being views. It also makes a few SQL queries for every version.  This causes timeouts for gems with a lot of versions. 

This is the dumb, simple fix to only show the last 20.  I'm playing around with the idea of adding a "load more" button, but that will involve a new endpoint to fetch the "more" from the server. Not sure if its worth the effort. 

/cc @grosser @jcheatham @waferbaby 